### PR TITLE
Update renovate.json: detect patch updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,14 @@
   "labels": [
     "dependencies"
   ],
+  "separateMinorPatch": true,
+  "packageRules": [
+    {
+      "matchPackageNames": ["/mariadb/"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    }
+  ],
   "customManagers": [
     {
       "customType": "regex",
@@ -14,8 +22,11 @@
         "/defaults/main.yml$/"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[a-z-0-9]+?))?\\s+[A-Za-z0-9_]+?(?:_version|_tag)\\s*:\\s*[\"']?(?<currentValue>.+?)[\"']?\\s"
-      ]
+        "(?<name>[A-Za-z0-9_]+):\\s*[\"']?(?<currentValue>.+?)[\"']?\\s"
+      ],
+      "depNameTemplate": "mariadb",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "semver"
     }
   ],
   "pre-commit": {

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,9 @@ mariadb_binary_name_dump: "{{ 'mysqldump' if mariadb_binary_name_shell == 'mysql
 
 mariadb_container_image_registry_prefix: docker.io/
 
+# Note that renovate.json is configured to detect patch updates only for safety, and Renovate will not
+# create a PR for obsolete tags which are not mentioned at https://hub.docker.com/_/mariadb.
+# Adding a line as below or editing the existing line is required for major or minor updates.
 mariadb_container_image_v10_10: "{{ mariadb_container_image_registry_prefix }}mariadb:10.10.7"
 mariadb_container_image_v10_11: "{{ mariadb_container_image_registry_prefix }}mariadb:10.11.10"
 mariadb_container_image_v11_1: "{{ mariadb_container_image_registry_prefix }}mariadb:11.1.6"


### PR DESCRIPTION
With this change, only PRs for patch level updates will be created:

- 10.11.10 -> 10.11.13
- 11.4.4 -> 11.4.7

Please note:
- Because `10.10.x`, `11.1.x`, and `11.2.x` version tags are no longer supported or provided according to https://hub.docker.com/_/mariadb, PRs for these will not be created.
- PRs for a later version like `12.x.x` and `11.8.x` are not created automatically either, because they expect a line like `mariadb_container_image_v12_0` and `mariadb_container_image_v11_8`, both of which do not exist on main.yml yet.

This change was tested at a test repository, and I have confirmed that the two PRs were created successfully.