### PR TITLE
add option to add label file to mariadb container

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,6 +52,10 @@ mariadb_container_additional_networks: "{{ mariadb_container_additional_networks
 mariadb_container_additional_networks_auto: []
 mariadb_container_additional_networks_custom: []
 
+# Use label file if variable is set. Suggested path:
+# mariadb_label_file_path: "{{ mariadb_base_path }}/labels"
+mariadb_label_file_path: ''
+
 # Controls how long to wait for the container to stop gracefully before killing it.
 # Because `devture_systemd_docker_base_container_stop_grace_time_seconds` may be quite short and databases are more important to stop gracefully,
 # we default to at least 30 seconds.

--- a/templates/systemd/mariadb.service.j2
+++ b/templates/systemd/mariadb.service.j2
@@ -25,6 +25,9 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
       --user={{ mariadb_uid }}:{{ mariadb_gid }} \
       --network={{ mariadb_container_network }} \
       --env-file={{ mariadb_base_path }}/env \
+{% if mariadb_label_file_path %}
+      --label-file={{ mariadb_label_file_path }} \
+{% endif %}
       --mount type=bind,src={{ mariadb_data_path }},dst=/var/lib/mysql \
       --mount type=bind,src={{ mariadb_base_path }}/my.cnf,dst=/root/.my.cnf,ro \
       --tmpfs=/tmp:rw,noexec,nosuid,size=512m \


### PR DESCRIPTION
This PR adds an option to add labels file to the mariadb container. It is disabled by default.
We use this role to deploy mariadb in itself, therefore we need to be able to access it from outside as well.